### PR TITLE
Maintenance: Update Ruby dependency to 2.7.3 for current 'develop' branch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-buster
+FROM ruby:2.7.3-buster
 ARG BUILD_DATE
 
 ENV ZAMMAD_DIR /opt/zammad


### PR DESCRIPTION
Today the 'develop' branch of Zammad was updated to Ruby 2.7.3. I hope this is the required update for this repository.