### PR TITLE
Maintenance: Drop no longer needed fetch_locales.rb call.

### DIFF
--- a/install-zammad.sh
+++ b/install-zammad.sh
@@ -53,9 +53,6 @@ elif [ "${RAILS_ENV}" == "development" ]; then
   bundle install --without mysql
 fi
 
-# fetch locales
-contrib/packager.io/fetch_locales.rb
-
 # create db & user
 ZAMMAD_DB_PASS="$(tr -dc A-Za-z0-9 < /dev/urandom | head -c10)"
 su - postgres -c "createdb -E UTF8 ${ZAMMAD_DB}"


### PR DESCRIPTION
Zammad does not require fetching locale data any more since https://github.com/zammad/zammad/commit/64a87b1c67c2dad7e9311491115f73606b14acc6. Drop it also in the docker build process.